### PR TITLE
Fixes stylesheet compilation error in Sample 13

### DIFF
--- a/Ultraviolet Framework Samples/UltravioletSample13 (Desktop)/Content/UI/Dialogs/EscMenuDialog/EscMenuDialogStyles.uvss
+++ b/Ultraviolet Framework Samples/UltravioletSample13 (Desktop)/Content/UI/Dialogs/EscMenuDialog/EscMenuDialogStyles.uvss
@@ -3,7 +3,7 @@
 	margin: 0;
 }
 
-#btn-resume, #btn-exit, 
+#btn-resume, #btn-exit
 {
 	margin: 0 0 0 8;
 }


### PR DESCRIPTION
Removes a comma which was leading to "Failed to compile style sheet due to parsing errors" error during sample 13 stylesheet compilation.