### PR TITLE
Added getter to get the current played animation

### DIFF
--- a/TwistedLogik.Ultraviolet/Graphics/Graphics2D/SpriteAnimationController.cs
+++ b/TwistedLogik.Ultraviolet/Graphics/Graphics2D/SpriteAnimationController.cs
@@ -190,6 +190,14 @@ namespace TwistedLogik.Ultraviolet.Graphics.Graphics2D
                 return 0;
             }
         }
+        
+        /// <summary>
+        /// Gets the current animation.
+        /// </summary>
+        public SpriteAnimation Animation
+        {
+            get { return animation; }
+        }
 
         // Animation properties.
         private Double timer;

--- a/TwistedLogik.Ultraviolet/Graphics/Graphics2D/SpriteAnimationController.cs
+++ b/TwistedLogik.Ultraviolet/Graphics/Graphics2D/SpriteAnimationController.cs
@@ -138,6 +138,14 @@ namespace TwistedLogik.Ultraviolet.Graphics.Graphics2D
         {
             return frame;
         }
+        
+        /// <summary>
+        /// Gets the current animation.
+        /// </summary>
+        public SpriteAnimation GetAnimation()
+        {
+            return animation;
+        }
 
         /// <summary>
         /// Gets a value indicating whether the controller is currently playing a fire-and-forget animation.
@@ -189,15 +197,7 @@ namespace TwistedLogik.Ultraviolet.Graphics.Graphics2D
                     return frame.Height;
                 return 0;
             }
-        }
-        
-        /// <summary>
-        /// Gets the current animation.
-        /// </summary>
-        public SpriteAnimation Animation
-        {
-            get { return animation; }
-        }
+        }        
 
         // Animation properties.
         private Double timer;


### PR DESCRIPTION
I needed a way to check what was the current animation of a SpriteAnimationController

example:
```csharp
                if(SpriteAnimationController.Animation == null || SpriteAnimationController.Animation.Name != "run")
                    SpriteAnimationController.PlayAnimation(Sprite["run"]);
```

I'm not sure if that's the best way to do it, but that's the only solution i found