### PR TITLE
Skip extern processing if dictionary is empty

### DIFF
--- a/Source/Ultraviolet.OpenGL/Shared/Graphics/ShaderSource.cs
+++ b/Source/Ultraviolet.OpenGL/Shared/Graphics/ShaderSource.cs
@@ -171,6 +171,8 @@ namespace Ultraviolet.OpenGL.Graphics
         /// </summary>
         private static Boolean ProcessExternDirective(String line, StringBuilder output, ShaderSourceMetadata ssmd, Dictionary<String, String> externs)
         {
+            if (externs.Count == 0) return false;
+            
             var externMatch = regexExternDirective.Match(line);
             if (externMatch.Success)
             {

--- a/Source/Ultraviolet.OpenGL/Shared/Graphics/ShaderSource.cs
+++ b/Source/Ultraviolet.OpenGL/Shared/Graphics/ShaderSource.cs
@@ -213,7 +213,7 @@ namespace Ultraviolet.OpenGL.Graphics
                 var externValue = String.Empty;
                 if (!externs.TryGetValue(externName, out externValue))
                 {
-                    Console.WriteLine($"WUUUUT: {externName}");
+                    // just skip, no need to throw an exception
                     return true;
                 }
                 


### PR DESCRIPTION
here is my shader

```glsl
#version 330

#extern skinningFlag
#extern numBones

// camera
uniform mat4 u_world;
uniform mat4 u_view;
uniform mat4 u_proj;

#ifdef numBones
#if numBones > 0
uniform mat4 u_bones[numBones];
#endif
#endif

// vertex
in vec3 uv_Position0;
in vec3 uv_Normal0;
in vec4 uv_Color0;
in vec2 uv_TextureCoordinate0;
#ifdef skinningFlag
in vec2 uv_BlendWeight0;
in vec2 uv_BlendWeight1;
in vec2 uv_BlendWeight2;
in vec2 uv_BlendWeight3;
#endif


// pass to frag
out vec2 vTextureCoordinate;
out vec3 vNormal;
out vec4 vColor;

void main()
{
#ifdef skinningFlag
    mat4 skinning = mat4(0.0);
    skinning += (uv_BlendWeight0.y) * (u_bones[int(uv_BlendWeight0.x)]);
    skinning += (uv_BlendWeight1.y) * (u_bones[int(uv_BlendWeight1.x)]);
    skinning += (uv_BlendWeight2.y) * (u_bones[int(uv_BlendWeight2.x)]);
    skinning += (uv_BlendWeight3.y) * (u_bones[int(uv_BlendWeight3.x)]);
    
    gl_Position = vec4(uv_Position0, 1.0) * skinning * (u_world * u_view * u_proj);
#else
    gl_Position = vec4(uv_Position0, 1.0) * (u_world * u_view * u_proj);
#endif    
                
    vNormal = uv_Normal0;
    vTextureCoordinate = vec2(uv_TextureCoordinate0.x, 1 - uv_TextureCoordinate0.y);
    vColor = uv_Color0;
}
```

But currently i can't compile a version without ``#define skinningFlag`` because it expect to replace the ``#extern skinningFlag`` no matter what

But i just want to to check ``skinningFlag``  exists or no, nothing else, i don't need it to be there if it is not needed