### PR TITLE
Fix NullReferenceException when the system cursor is used

### DIFF
--- a/Source/Ultraviolet.Presentation/Shared/Controls/TextBox.cs
+++ b/Source/Ultraviolet.Presentation/Shared/Controls/TextBox.cs
@@ -614,7 +614,10 @@ namespace Ultraviolet.Presentation.Controls
         {
             if (IsMouseCaptured && IsMouseWithinEditor())
             {
-                data.Cursor = TextEditor?.Cursor.Resource.Cursor ?? data.Cursor;
+                if (TextEditor?.Cursor.Resource != null)
+                {
+                    data.Cursor = TextEditor?.Cursor.Resource.Cursor ?? data.Cursor;
+                }
                 data.Handled = true;
             }
             base.OnQueryCursor(device, data);

--- a/Source/Ultraviolet.Presentation/Shared/Controls/TextBox.cs
+++ b/Source/Ultraviolet.Presentation/Shared/Controls/TextBox.cs
@@ -616,7 +616,7 @@ namespace Ultraviolet.Presentation.Controls
             {
                 if (TextEditor?.Cursor.Resource != null)
                 {
-                    data.Cursor = TextEditor?.Cursor.Resource.Cursor ?? data.Cursor;
+                    data.Cursor = TextEditor?.Cursor.Resource?.Cursor ?? data.Cursor;
                 }
                 data.Handled = true;
             }


### PR DESCRIPTION
When no cursor is set (so the system cursor is used), the EditBox throws a NullReferenceException because it tries to access the resource of the system cursor - which has no resource.

This pull request fixes the issue without breaking the normal behaviour.

If you want to verify that this works, my fork contains a branch system-cursor before and after the fix (which is the last commit) and a branch uv-cursor before and after the fix (which is also the last commit) so you can verify that this change does not break old behaviour and fixes the NRE.