### PR TITLE
Set position after setting size for centering window

### DIFF
--- a/Source/Ultraviolet.SDL2/Shared/Platform/SDL2UltravioletWindow.cs
+++ b/Source/Ultraviolet.SDL2/Shared/Platform/SDL2UltravioletWindow.cs
@@ -199,9 +199,9 @@ namespace Ultraviolet.SDL2.Platform
             Contract.EnsureNotDisposed(this, Disposed);
             Contract.EnsureRange(scale >= 1f, nameof(scale));
 
-            this.WindowedPosition = new Point2((Int32)SDL_WINDOWPOS_CENTERED_MASK, (Int32)SDL_WINDOWPOS_CENTERED_MASK);
             this.WindowedClientSize = size;
             this.WindowScale = scale;
+            this.WindowedPosition = new Point2((Int32)SDL_WINDOWPOS_CENTERED_MASK, (Int32)SDL_WINDOWPOS_CENTERED_MASK);
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
The window position need to be set after the size when you use `SetWindowedClientSizeCentered`, if not the window will be centered with the previous size.
From my tests I believe the window's size is remembered when you close and reopen the app.